### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
@@ -88,5 +88,10 @@
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
         </dependency>
+        <dependency>
+			    <groupId>org.rocksdb</groupId>
+			    <artifactId>rocksdbjni</artifactId>
+			    <version>5.15.10</version>
+		    </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-streams</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
@@ -89,9 +89,9 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-			    <groupId>org.rocksdb</groupId>
-			    <artifactId>rocksdbjni</artifactId>
-			    <version>5.15.10</version>
-		    </dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>5.15.10</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Current dependencies provoked a crash when running on Windows. Adding the rocksdbjni dependency (used by kafka) in a new version and updating kafka-streams dependecy to 1.0.1 fixes this issue.